### PR TITLE
Update xivo-backup - allow backup to keep var/cache dir

### DIFF
--- a/bin/xivo-backup
+++ b/bin/xivo-backup
@@ -47,7 +47,7 @@ case "${BACKUP_TYPE}" in
                  /var/lib/asterisk/moh
                  /var/spool/asterisk/voicemail
                  /var/spool/asterisk/monitor"
-    EXCLUDE_FILES="/var/lib/xivo-provd/plugins/*/var/cache
+    EXCLUDE_FILES="/var/lib/xivo-provd/plugins/*/var/cache/*
                    /var/spool/asterisk/monitor
                    /var/spool/asterisk/meetme"
 


### PR DESCRIPTION
When restoring a data xivo-backup, var/cache is required for a plugin to work properly.
Thus we need to keep the var/cache tree under plugin backup.